### PR TITLE
fix hugo docker image

### DIFF
--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,5 +1,3 @@
-FROM node:10-alpine
+FROM linuxbrew/brew
 
-RUN apk update
-
-RUN apk add git hugo
+RUN brew install hugo


### PR DESCRIPTION
Fixed the Hugo docker image. The Hugo version from the apk package manager from Linux alpine is out of date.