### PR TITLE
feat: add hugo extended

### DIFF
--- a/hugo-extended/Dockerfile
+++ b/hugo-extended/Dockerfile
@@ -1,0 +1,13 @@
+ARG NODE_VERSION
+
+FROM node:$NODE_VERSION
+
+ARG HUGO_VERSION=0.98.0
+
+RUN apt-get update && apt-get install -y wget
+
+RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
+    tar -xf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -C /usr/local/bin && \
+    hugo version && rm hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
+    
+RUN wget -q -O - https://raw.githubusercontent.com/canha/golang-tools-install-script/master/goinstall.sh | bash

--- a/hugo-extended/Dockerfile
+++ b/hugo-extended/Dockerfile
@@ -6,8 +6,8 @@ ARG HUGO_VERSION=0.98.0
 
 RUN apt-get update && apt-get install -y wget
 
-RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
-    tar -xf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -C /usr/local/bin && \
+RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz && \
+    tar -xf hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz -C /usr/local/bin && \
     hugo version && rm hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
     
 RUN wget -q -O - https://raw.githubusercontent.com/canha/golang-tools-install-script/master/goinstall.sh | bash

--- a/hugo-extended/Dockerfile
+++ b/hugo-extended/Dockerfile
@@ -6,6 +6,10 @@ ARG HUGO_VERSION=0.98.0
 
 RUN apt-get update && apt-get install -y wget
 
+RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
+    tar -xf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -C /usr/local/bin && \
+    hugo version && rm hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+
 RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz && \
     tar -xf hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz -C /usr/local/bin && \
     hugo version && rm hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz

--- a/hugo-extended/hooks/build
+++ b/hugo-extended/hooks/build
@@ -2,6 +2,7 @@
 
 NODE_VERSION=$(echo $DOCKER_TAG | cut -d "-" -f2)
 
+# If running on M1 add --platform linux/x86_64 on docker build
 if [ $DOCKER_TAG == "latest" ]
 then
   docker build . --build-arg NODE_VERSION=${DOCKER_TAG} -t ${IMAGE_NAME}

--- a/hugo-extended/hooks/build
+++ b/hugo-extended/hooks/build
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+NODE_VERSION=$(echo $DOCKER_TAG | cut -d "-" -f2)
+
+if [ $DOCKER_TAG == "latest" ]
+then
+  docker build . --build-arg NODE_VERSION=${DOCKER_TAG} -t ${IMAGE_NAME}
+else
+  docker build . --build-arg NODE_VERSION=${NODE_VERSION} -t ${IMAGE_NAME}
+fi
+
+


### PR DESCRIPTION
# Changes

We are using fleek and a hugo theme that requires the hugo extended version. This change will add the dockerfile that will build the image with hugo-extended version 0.98.0 (latest as of this PR).

- Added hugo extended build

Resolves: https://github.com/FleekHQ/site-builder-docker-images/issues/10

# Verification
Image built here: https://hub.docker.com/repository/docker/alvinpai/hugo-extended-custom
Project here
![image](https://user-images.githubusercontent.com/4479171/166585538-3792760e-140a-4c54-b333-1051decd8eca.png)
![image](https://user-images.githubusercontent.com/4479171/166585551-76a6435a-ec99-47f3-91b9-b9734e7e74be.png)
