### PR TITLE
Bump Hugo to recent version

### DIFF
--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -2,7 +2,7 @@ ARG NODE_VERSION
 
 FROM node:$NODE_VERSION
 
-ARG HUGO_VERSION=0.80.0
+ARG HUGO_VERSION=0.120.3
 
 RUN apt-get update && apt-get install -y wget
 


### PR DESCRIPTION
This will enable support for partials in templates, among other things. Which are pretty common nowadays in Hugo templates, so would be great to get this version bumped, so we don't get errors like the following:

`
Error: Error building site: failed to render pages: render of "home" failed: execute of template failed: template: index.html:10:4: executing "index.html" at <partial "head" .>: error calling partial: "/workspace/layouts/partials/head.html:16:56": execute of template failed: template: partials/head.html:16:56: executing "partials/head.html" at <resources.ExecuteAsTemplate>: error calling ExecuteAsTemplate: type <nil> not supported in Resource transformations
`